### PR TITLE
Fix reflection warnings by adding type definition

### DIFF
--- a/src/ring/middleware/accept.clj
+++ b/src/ring/middleware/accept.clj
@@ -43,7 +43,7 @@
 			(clojure.string/split pattern #"/" 2))))
 
 (defn- lang-match
-	[cand pattern]
+	[^String cand ^String pattern]
 	(let
 		[cand (.toLowerCase cand)
 		 pattern (.toLowerCase pattern)


### PR DESCRIPTION
Two reflection warnings were fixed by adding type definition to both parameters of ring.middleware.accept/lang-match
